### PR TITLE
Fix startup failure due to outdated with-contenv path

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## chrony-nts 1.0.0-beta.5
+
+- Fix startup failure caused by outdated `/command/with-contenv` path.
+
 ## chrony-nts 1.0.0-beta.1
 
 **Pre-release (beta)**

--- a/chrony/config.yaml
+++ b/chrony/config.yaml
@@ -1,7 +1,7 @@
 name: "Chrony NTP Server (with NTS client)"
 slug: "chrony-nts"
 description: "Secure NTP server for your LAN; optionally authenticates upstream time with NTS."
-version: "1.0.0-beta.4"
+version: "1.0.0-beta.5"
 arch:
   - aarch64
   - amd64

--- a/chrony/rootfs/etc/cont-init.d/10-chrony.sh
+++ b/chrony/rootfs/etc/cont-init.d/10-chrony.sh
@@ -1,4 +1,4 @@
-#!/command/with-contenv bashio
+#!/usr/bin/with-contenv bashio
 set -Eeuo pipefail
 
 CONF="/etc/chrony/chrony.conf"

--- a/chrony/rootfs/etc/services.d/chronyd/run
+++ b/chrony/rootfs/etc/services.d/chronyd/run
@@ -1,4 +1,4 @@
-#!/command/with-contenv bashio
+#!/usr/bin/with-contenv bashio
 set -Eeuo pipefail
 
 CONF="/etc/chrony/chrony.conf"


### PR DESCRIPTION
## Summary
- use `/usr/bin/with-contenv` in init and service scripts
- bump addon version to 1.0.0-beta.5 and document fix

## Testing
- `bash -n chrony/rootfs/etc/cont-init.d/10-chrony.sh chrony/rootfs/etc/services.d/chronyd/run`
- `python3 - <<'PY'
import yaml
print('config loaded', bool(yaml.safe_load(open('chrony/config.yaml'))))
PY`
